### PR TITLE
fix: ferme la vérification d'expiration quand on "éteint" locky

### DIFF
--- a/lib/locky.js
+++ b/lib/locky.js
@@ -154,6 +154,7 @@ class Locky extends EventEmitter {
    */
 
   close(callback) {
+    Object.keys(this._resourceTimeouts).forEach((resource) => this._clearExpiration(resource));
     return nodeify(this._close(), callback);
   }
 


### PR DESCRIPTION
Quand on clôt locky, il faut aussi clôre l'exécution des checks expiration