### PR TITLE
feat: on s'appuie sur redis pour catcher toutes les expirations de locks

### DIFF
--- a/lib/locky.js
+++ b/lib/locky.js
@@ -30,7 +30,7 @@ class Locky extends EventEmitter {
     this.redis = this.createRedisClient(options.redis);
     this._resourceTimeouts = {};
 
-    this.expiration = setInterval(() => this.expirationCollector(), this.ttl / 2);
+    this.expiration = setInterval(() => this.expirationCollector(), this.ttl * 0.5);
     this.redis.on('error', (err) => this.emit('error', err));
   }
 
@@ -48,9 +48,7 @@ class Locky extends EventEmitter {
       return nodeify(this.lockPromise(options), callback);
    }
 
-  lockPromise(options) {
-    options = options || {};
-
+  lockPromise(options = {}) {
     // Format key with resource id.
     const key = resourceKey.format(options.resource);
 
@@ -185,7 +183,7 @@ class Locky extends EventEmitter {
     })
     .then((results) => {
       const expired = _(keys)
-      .zipWith(results, (key, result) => result < 0 ? { key, resource: resourceKey.parse(key )} : null)
+      .zipWith(results, (key, result) => result < 0 ? { key, resource: resourceKey.parse(key) } : null)
       .compact()
       .value();
 
@@ -194,6 +192,7 @@ class Locky extends EventEmitter {
         this.emit('expire', resource);
         this.redis.srem(this.set, key);
       });
+      this.redis.expire(this.set, this.ttl * 2);
 
       return this.redis.exec();
     })

--- a/lib/locky.js
+++ b/lib/locky.js
@@ -25,10 +25,12 @@ class Locky extends EventEmitter {
       redis: {}
     });
 
+    this.set = options.set || 'locky:current:locks';
     this.ttl = options.ttl;
-    this.redis = this._createRedisClient(options.redis);
+    this.redis = this.createRedisClient(options.redis);
     this._resourceTimeouts = {};
 
+    this.expiration = setInterval(() => this.expirationCollector(), this.ttl / 2);
     this.redis.on('error', (err) => this.emit('error', err));
   }
 
@@ -42,11 +44,11 @@ class Locky extends EventEmitter {
    * @param {Promise} [callback] Optional callback
    */
 
-   lock(options, callback) {
-      return nodeify(this._lock(options), callback);
+  lock(options, callback) {
+      return nodeify(this.lockPromise(options), callback);
    }
 
-  _lock(options) {
+  lockPromise(options) {
     options = options || {};
 
     // Format key with resource id.
@@ -55,20 +57,20 @@ class Locky extends EventEmitter {
     // Define the method to use.
     const method = options.force ? 'set' : 'setnx';
 
+    this.redis.multi();
+    this.redis[method](key, options.locker);
+    this.redis.sadd(this.set, key);
+
     // Set the lock key.
-    return this
-    .redis[method](key, options.locker)
+    return this.redis.exec()
     .then((res) => {
-      const success = res === 1 || res === 'OK';
+      const success = _.first(res) !== 0;
 
       if (! this.ttl || ! success) return success;
 
-      return this
-      .redis.pexpire(key, this.ttl)
-      .then(() => {
-        this._listenExpiration(options.resource);
-        return success;
-      });
+      return this.redis
+      .pexpire(key, this.ttl)
+      .then(() => success);
     })
     .then((success) => {
       if (success) {
@@ -86,11 +88,11 @@ class Locky extends EventEmitter {
    * @param {function} [callback] Optional callback
    */
 
-   refresh(resource, callback) {
-      return nodeify(this._refresh(resource), callback);
+  refresh(resource, callback) {
+      return nodeify(this.refreshPromise(resource), callback);
    }
 
-  _refresh(resource) {
+  refreshPromise(resource) {
     return new Promise((resolve, reject) => {
       // If there is no TTL, do nothing.
       if (!this.ttl) return resolve();
@@ -99,11 +101,9 @@ class Locky extends EventEmitter {
       const key = resourceKey.format(resource);
 
       // Set the TTL of the key.
-      this.redis.pexpire(key, this.ttl)
+      return this.redis
+      .pexpire(key, this.ttl)
       .then(resolve, reject);
-    })
-    .then(() => {
-      this._listenExpiration(resource);
     });
   }
 
@@ -115,20 +115,24 @@ class Locky extends EventEmitter {
    */
 
   unlock(resource, callback) {
-    return nodeify(this._unlock(resource), callback);
+    return nodeify(this.unlockPromise(resource), callback);
   }
 
-  _unlock(resource) {
+  unlockPromise(resource) {
     // Format key with resource id.
     const key = resourceKey.format(resource);
 
+    this.redis.multi();
+    this.redis.del(key);
+    this.redis.srem(this.set, key);
+
     // Remove the key.
-    return this.redis.del(key)
+    return this.redis.exec()
     .then((res) => {
-      if (res === 0) return;
+      if (_.first(res) === 0) return false;
 
       this.emit('unlock', resource);
-      this._clearExpiration(resource);
+      return true;
     });
   }
 
@@ -140,64 +144,63 @@ class Locky extends EventEmitter {
    */
 
   getLocker(resource, callback) {
-    return nodeify(this._getLocker(resource), callback);
+    return nodeify(this.getLockerPromise(resource), callback);
   }
 
-  _getLocker(resource) {
+  getLockerPromise(resource) {
     return this.redis.get(resourceKey.format(resource));
   }
 
   /**
    * Close the client.
-   *
-   * @param {function} [callback] Optional callback
    */
 
-  close(callback) {
-    return nodeify(this._close(), callback);
-  }
+  close() {
+    if (this.expirationWorking) {
+      return this.once('expirationWorking', () => this.close());
+    }
 
-  _close() {
+    clearInterval(this.expiration);
     return this.redis.quit();
   }
 
   /**
-   * Listen expiration.
-   *
-   * @param {string} resource Resource
+   * Check for expirations
    */
 
-  _listenExpiration(resource) {
-    const bindedExpire = this._onExpire.bind(this, resource);
-    this._resourceTimeouts[resource] = setTimeout(bindedExpire, this.ttl);
-  }
+  expirationCollector() {
+    if (!this.ttl || this.expirationWorking) return;
 
-  /**
-   * Clear timeout on expiration.
-   *
-   * @param {string} resource Resource
-   */
+    this.expirationWorking = true;
 
-  _clearExpiration(resource) {
-    const timeout = this._resourceTimeouts[resource];
+    let keys;
 
-    if (timeout) clearTimeout(timeout);
-  }
+    return this.redis.smembers(this.set)
+    .then((_keys) => {
+      keys = _keys;
 
-  /**
-   * Called when a lock expire.
-   *
-   * @param {string} resource
-   */
+      this.redis.multi();
+      keys.forEach((key) => this.redis.ttl(key));
+      return this.redis.exec();
+    })
+    .then((results) => {
+      const expired = _(keys)
+      .zipWith(results, (key, result) => result < 0 ? { key, resource: resourceKey.parse(key )} : null)
+      .compact()
+      .value();
 
-  _onExpire(resource) {
-    return this.getLocker(resource)
-    .then((locker) => {
-      // If there is a locker, the key has not expired.
-      if (locker) return;
+      this.redis.multi();
+      expired.forEach(({ key, resource }) => {
+        this.emit('expire', resource);
+        this.redis.srem(this.set, key);
+      });
 
-      // Emit an expire event.
-      this.emit('expire', resource);
+      return this.redis.exec();
+    })
+    .then(() => {
+      this.expirationWorking = false;
+      this.emit('expirationWorking', false);
+      return true;
     });
   }
 
@@ -207,7 +210,7 @@ class Locky extends EventEmitter {
    * @param {object|function} options
    */
 
-  _createRedisClient(options) {
+  createRedisClient(options) {
     if (_.isFunction(options)) return options();
 
     return redis.createClient(options);


### PR DESCRIPTION
fix/feat
Précédemment, des scripts étaient enregistrés en setTimeout pour vérifier si une clé est expirée.
Pb : si on kille le process, la clé n'est pas vérifiée.

Maintenant, on stocke dans un set redis les clés à checker, et un script passe vérifier toutes les clés à interval régulier (ttl * 0.5)
Résultat : un locky sur un process pourra vérifier la fraîcheur de toutes les clés.

A noter : en cas d'interruption de locky, les clés disparaissent au bout d'un certain temps (ttl).
On en fait de même avec le set (ttl * 2), qui devient inutile si les clés n'existent plus.

A noter : le set redis a des valeurs uniques. On ne peut pas avoir 2 fois la même clé. Donc le risque d'envoyer 2 expire pour la même clé est infime.

++ cluster