### PR TITLE
fix: évite multi et la concurrency dans expirate collector

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -30,6 +30,7 @@
   "debug": false,
   "eqnull": true,
   "esnext": true,
+  "-W138": true,
   "evil": false,
   "expr": false,
   "funcscope": false,

--- a/lib/locky.js
+++ b/lib/locky.js
@@ -1,12 +1,8 @@
-/**
- * Module dependencies.
- */
-
-const EventEmitter = require('events').EventEmitter;
+const EventEmitter = require('events');
 const _ = require('lodash');
-const redis = require('then-redis');
+const Promise = require('bluebird');
+const redis = require('./redis');
 const resourceKey = require('./resource-key');
-const nodeify = require('promise-nodeify');
 
 /**
  * Create a new Locky client.
@@ -27,12 +23,12 @@ class Locky extends EventEmitter {
 
     this.set = options.set || 'locky:current:locks';
     this.ttl = options.ttl;
-    this.redis = this.createRedisClient(options.redis);
+    this.redis = redis.createClient(options.redis);
     this._resourceTimeouts = {};
 
     // for expirate listener
     this.expirateInterval = setInterval(() => this.expirateListener(), this.ttl);
-    this.expirateResource = 'locky:expirate:collector';
+    this.expirateResource = 'locky:expirate:worker';
     this.expirateWorking = false;
     this.expirateListener();
 
@@ -50,36 +46,37 @@ class Locky extends EventEmitter {
    */
 
   lock(options, callback) {
-      return nodeify(this.lockPromise(options), callback);
-   }
+    if (!_.isFunction(callback)) return this.lockPromise(options);
+    return this.lockPromise(options).asCallback(callback);
+  }
 
   lockPromise(options = {}) {
     // Format key with resource id.
     const key = resourceKey.format(options.resource);
 
+    if (!key) return Promise.resolve(true);
+    if (!options.locker) return Promise.resolve(true);
+
     // Define the method to use.
-    const method = options.force ? 'set' : 'setnx';
+    const method = options.force ? 'setAsync' : 'setnxAsync';
 
     // add the lock to the unique set
-    this.redis.sadd(this.set, key);
-
-    // add the lock key.
-    return this.redis[method](key, options.locker)
-    .then((res) => {
+    return this.redis.saddAsync(this.set, key)
+    .then(() => this.redis[method](key, options.locker))
+    .then(res => {
       const success = res !== 0;
 
-      if (! this.ttl || ! success) return success;
+      if (!this.ttl || !success) return Promise.resolve(success);
 
-      return this.redis
-      .pexpire(key, this.ttl)
-      .then(() => success);
+      return this.redis.pexpireAsync(key, this.ttl)
+      .then(() => Promise.resolve(success));
     })
-    .then((success) => {
+    .then(success => {
       if (success) {
         this.emit('lock', options.resource, options.locker);
       }
 
-      return success;
+      return Promise.resolve(success);
     });
   }
 
@@ -91,22 +88,19 @@ class Locky extends EventEmitter {
    */
 
   refresh(resource, callback) {
-      return nodeify(this.refreshPromise(resource), callback);
-   }
+    if (!_.isFunction(callback)) return this.lockPromise(resource);
+    return this.lockPromise(resource).asCallback(callback);
+  }
 
   refreshPromise(resource) {
-    return new Promise((resolve, reject) => {
-      // If there is no TTL, do nothing.
-      if (!this.ttl) return resolve();
+    // If there is no TTL, do nothing.
+    if (!this.ttl) return Promise.resolve(true);
 
-      // Format key with resource id.
-      const key = resourceKey.format(resource);
+    // Format key with resource id.
+    const key = resourceKey.format(resource);
 
-      // Set the TTL of the key.
-      return this.redis
-      .pexpire(key, this.ttl)
-      .then(resolve, reject);
-    });
+    // Set the TTL of the key.
+    return this.redis.pexpireAsync(key, this.ttl);
   }
 
   /**
@@ -117,7 +111,8 @@ class Locky extends EventEmitter {
    */
 
   unlock(resource, callback) {
-    return nodeify(this.unlockPromise(resource), callback);
+    if (!_.isFunction(callback)) return this.unlockPromise(resource);
+    return this.unlockPromise(resource).asCallback(callback);
   }
 
   unlockPromise(resource) {
@@ -125,15 +120,13 @@ class Locky extends EventEmitter {
     const key = resourceKey.format(resource);
 
     // Remove the ky from the unique set
-    this.redis.srem(this.set, key);
-
-    // Remove the key.
-    return this.redis.del(key)
+    return this.redis.sremAsync(this.set, key)
+    .then(() => this.redis.delAsync(key))
     .then((res) => {
-      if (res === 0) return false;
+      if (res === 0) return Promise.resolve(true);
 
       this.emit('unlock', resource);
-      return true;
+      return Promise.resolve(true);
     });
   }
 
@@ -145,11 +138,12 @@ class Locky extends EventEmitter {
    */
 
   getLocker(resource, callback) {
-    return nodeify(this.getLockerPromise(resource), callback);
+    if (!_.isFunction(callback)) return this.getLockerPromise(resource);
+    return this.getLockerPromise(resource).asCallback(callback);
   }
 
   getLockerPromise(resource) {
-    return this.redis.get(resourceKey.format(resource));
+    return this.redis.getAsync(resourceKey.format(resource));
   }
 
   /**
@@ -157,22 +151,21 @@ class Locky extends EventEmitter {
    */
 
   close(callback) {
-    return nodeify(this.closePromise(), callback);
+    if (!_.isFunction(callback)) return this.closePromise();
+    return this.closePromise().asCallback(callback);
   }
 
   closePromise() {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       const quit = () => {
         clearInterval(this.expirateInterval);
         this.redis.quit();
-        return resolve(true);
+        resolve(true);
       };
 
       if (this.expirateWorking) {
-        this.once('expirateCollectorEnd', () => quit);
-      }
-
-      return quit();
+        this.once('expirateEnd', quit);
+      } else quit();
     });
   }
 
@@ -184,47 +177,48 @@ class Locky extends EventEmitter {
   expirateListener() {
     if (!this.ttl || this.expirateWorking) return;
 
-    return this.redis.setnx(this.expirateResource, 'OK')
-    .then(result => {
-      if (result === 0) return Promise.resolve(false);
+    // try to set the worker token
+    return this.redis.setnxAsync(this.expirateResource, 'OK')
+    .then(hasToken => {
+      // has not token, an other working
+      if (!hasToken) return;
+      // expirate worker is locked
       this.expirateWorking = true;
-      return this.expirateCollector();
+      // refresh the ttl of the worker token
+      return this.redis.pexpire(this.expirateResource, this.ttl);
     })
-    .then(() => {
+    // launch expirate worker
+    .then(() => this.expirateWorker())
+    // delete the worker token
+    .then(() => this.redis.delAsync(this.expirateResource))
+    .catch(err => this.emit('error', err))
+    .finally(() => {
       this.expirateWorking = false;
-      this.emit('expirateCollectorEnd', true);
+      this.emit('expirateEnd', true);
 
-      return this.redis.del(this.expirateResource);
-    })
-    .catch((err) => {
-      this.emit('error', err);
-      this.expirateWorking = false;
-      this.emit('expirateCollectorEnd', true);
-
-      return this.redis.del(this.expirateResource);
+      return Promise.resolve(true);
     });
   }
 
   /**
-   * Launch expirations collector
+   * Worker that collects expirations to emit them
    */
 
-  expirateCollector() {
+  expirateWorker() {
     let keys;
 
-    return this.redis
-    .smembers(this.set)
-    .then((_keys) => {
+    return this.redis.smembersAsync(this.set)
+    .then(_keys => {
       keys = _keys;
 
       // if there is not keys, we dont do anything
-      if (! keys) return Promise.resolve(false);
+      if (!keys) return;
 
-      return Promise.all(keys.map(key => this.redis.pttl(key)));
+      const batch = this.redis.batch();
+      keys.forEach((key) => batch.pttl(key));
+      return batch.execAsync();
     })
-    .then((results) => {
-      if (! keys) return Promise.resolve(true);
-
+    .then(results => {
       const expired = _(keys)
       .zipWith(results, (key, result) => {
         return result === -2 ? { key, resource: resourceKey.parse(key) } : null;
@@ -233,26 +227,13 @@ class Locky extends EventEmitter {
       .value();
 
       // if there is not expired key, we dont do anything
-      if (_.isEmpty(expired)) return Promise.resolve(true);
+      if (_.isEmpty(expired)) return;
 
       expired.forEach(({ key, resource }) => this.emit('expire', resource));
 
-      this.redis.srem(this.set, ..._.map(expired, 'key'));
-
-      return this.redis.pexpire(this.set, this.ttl * 2);
-    });
-  }
-
-  /**
-   * Create the redis client.
-   *
-   * @param {object|function} options
-   */
-
-  createRedisClient(options) {
-    if (_.isFunction(options)) return options();
-
-    return redis.createClient(options);
+      return this.redis.sremAsync(this.set, ..._.map(expired, 'key'));
+    })
+    .then(() => this.redis.pexpireAsync(this.set, this.ttl * 2));
   }
 }
 

--- a/lib/locky.js
+++ b/lib/locky.js
@@ -30,7 +30,12 @@ class Locky extends EventEmitter {
     this.redis = this.createRedisClient(options.redis);
     this._resourceTimeouts = {};
 
-    this.expiration = setInterval(() => this.expirationCollector(), this.ttl * 0.5);
+    // for expirate listener
+    this.expirateInterval = setInterval(() => this.expirateListener(), this.ttl);
+    this.expirateResource = 'locky:expirate:collector';
+    this.expirateWorking = false;
+    this.expirateListener();
+
     this.redis.on('error', (err) => this.emit('error', err));
   }
 
@@ -55,14 +60,13 @@ class Locky extends EventEmitter {
     // Define the method to use.
     const method = options.force ? 'set' : 'setnx';
 
-    this.redis.multi();
-    this.redis[method](key, options.locker);
+    // add the lock to the unique set
     this.redis.sadd(this.set, key);
 
-    // Set the lock key.
-    return this.redis.exec()
+    // add the lock key.
+    return this.redis[method](key, options.locker)
     .then((res) => {
-      const success = _.first(res) !== 0;
+      const success = res !== 0;
 
       if (! this.ttl || ! success) return success;
 
@@ -120,14 +124,13 @@ class Locky extends EventEmitter {
     // Format key with resource id.
     const key = resourceKey.format(resource);
 
-    this.redis.multi();
-    this.redis.del(key);
+    // Remove the ky from the unique set
     this.redis.srem(this.set, key);
 
     // Remove the key.
-    return this.redis.exec()
+    return this.redis.del(key)
     .then((res) => {
-      if (_.first(res) === 0) return false;
+      if (res === 0) return false;
 
       this.emit('unlock', resource);
       return true;
@@ -153,53 +156,90 @@ class Locky extends EventEmitter {
    * Close the client.
    */
 
-  close() {
-    if (this.expirationWorking) {
-      return this.once('expirationWorking', () => this.close());
-    }
+  close(callback) {
+    return nodeify(this.closePromise(), callback);
+  }
 
-    clearInterval(this.expiration);
-    return this.redis.quit();
+  closePromise() {
+    return new Promise((resolve) => {
+      const quit = () => {
+        clearInterval(this.expirateInterval);
+        this.redis.quit();
+        return resolve(true);
+      };
+
+      if (this.expirateWorking) {
+        this.once('expirateCollectorEnd', () => quit);
+      }
+
+      return quit();
+    });
   }
 
   /**
    * Check for expirations
+   * Cluster singleton
    */
 
-  expirationCollector() {
-    if (!this.ttl || this.expirationWorking) return;
+  expirateListener() {
+    if (!this.ttl || this.expirateWorking) return;
 
-    this.expirationWorking = true;
+    return this.redis.setnx(this.expirateResource, 'OK')
+    .then(result => {
+      if (result === 0) return Promise.resolve(false);
+      this.expirateWorking = true;
+      return this.expirateCollector();
+    })
+    .then(() => {
+      this.expirateWorking = false;
+      this.emit('expirateCollectorEnd', true);
 
+      return this.redis.del(this.expirateResource);
+    })
+    .catch((err) => {
+      this.emit('error', err);
+      this.expirateWorking = false;
+      this.emit('expirateCollectorEnd', true);
+
+      return this.redis.del(this.expirateResource);
+    });
+  }
+
+  /**
+   * Launch expirations collector
+   */
+
+  expirateCollector() {
     let keys;
 
-    return this.redis.smembers(this.set)
+    return this.redis
+    .smembers(this.set)
     .then((_keys) => {
       keys = _keys;
 
-      this.redis.multi();
-      keys.forEach((key) => this.redis.ttl(key));
-      return this.redis.exec();
+      // if there is not keys, we dont do anything
+      if (! keys) return Promise.resolve(false);
+
+      return Promise.all(keys.map(key => this.redis.pttl(key)));
     })
     .then((results) => {
+      if (! keys) return Promise.resolve(true);
+
       const expired = _(keys)
-      .zipWith(results, (key, result) => result < 0 ? { key, resource: resourceKey.parse(key) } : null)
+      .zipWith(results, (key, result) => {
+        return result === -2 ? { key, resource: resourceKey.parse(key) } : null;
+      })
       .compact()
       .value();
 
-      this.redis.multi();
-      expired.forEach(({ key, resource }) => {
-        this.emit('expire', resource);
-        this.redis.srem(this.set, key);
-      });
-      this.redis.expire(this.set, this.ttl * 2);
+      // if there is not expired key, we dont do anything
+      if (_.isEmpty(expired)) return Promise.resolve(true);
 
-      return this.redis.exec();
-    })
-    .then(() => {
-      this.expirationWorking = false;
-      this.emit('expirationWorking', false);
-      return true;
+      expired.forEach(({ key, resource }) => this.emit('expire', resource));
+
+      this.redis.srem(this.set, ..._.map(expired, 'key'));
+
+      return this.redis.pexpire(this.set, this.ttl * 2);
     });
   }
 

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,0 +1,13 @@
+const bluebird = require('bluebird');
+const redis = require('redis');
+
+bluebird.promisifyAll(redis.RedisClient.prototype);
+bluebird.promisifyAll(redis.Multi.prototype);
+
+/**
+ * Create the redis client.
+ *
+ * @param {object|function} options
+ */
+
+module.exports.createClient = (options) => redis.createClient(options);

--- a/package.json
+++ b/package.json
@@ -27,9 +27,8 @@
     "sinon-chai": "^2.8.0"
   },
   "dependencies": {
+    "bluebird": "^3.5.0",
     "lodash": "^4.17.4",
-    "promise-nodeify": "^1.0.0",
-    "redis": "^2.6.5",
-    "then-redis": "^2.0.1"
+    "redis": "^2.7.0"
   }
 }

--- a/test/locky.js
+++ b/test/locky.js
@@ -136,7 +136,7 @@ describe('Locky', () => {
         resource: 'article4',
         locker: 'john'
       })
-      .then(() => Promise.delay(300))
+      .then(() => Promise.delay(250))
       .then(() => {
         expect(spy).to.be.calledWith('article4');
         return true;
@@ -181,7 +181,7 @@ describe('Locky', () => {
       return locky.redis.setAsync('lock:resource:article8', 'john')
       .then(() => locky.redis.saddAsync(locky.set, 'lock:resource:article8'))
       .then(() => locky.redis.pexpireAsync('lock:resource:article8', 20))
-      .then(() => Promise.delay(300))
+      .then(() => Promise.delay(250))
       .then(() => {
         expect(spy).to.be.calledWith('article8');
         return true;
@@ -240,7 +240,7 @@ describe('Locky', () => {
         locker: 'john'
       })
       .then(() => locky.unlock('article13'))
-      .then(() => Promise.delay(300))
+      .then(() => Promise.delay(250))
       .then(() => {
         expect(spy).to.not.be.called;
         return true;


### PR DESCRIPTION
Fix : 
- suppression du multi, car le `GET` renvoyait `QUEUED` au lieu de la valeur attendue durant un multi http://www.rediscookbook.org/get_and_delete.html
- le script qui vérifie si les clés sont expirées s'exécute maintenant en "singleton" pour éviter d'avoir plusieurs `expire` pour une même ressource
- le `close` est désormais asynchrone pour attendre que les commandes redis soient bien exécutées

refacto : 
- utilisation de `redis` à la place de `then-redis` : https://github.com/mjackson/then-redis#this-package-is-no-longer-maintained-node_redis-now-includes-support-for-promises-in-core-so-this-is-no-longer-needed
- utilisation de `bluebird` pour un code plus fin