### PR TITLE
fix(redis): flush les commandes redis à l'arrêt du service

### DIFF
--- a/lib/locky.js
+++ b/lib/locky.js
@@ -159,7 +159,7 @@ class Locky extends EventEmitter {
     return new Promise(resolve => {
       const quit = () => {
         clearInterval(this.expirateInterval);
-        this.redis.quit();
+        this.redis.end(true);
         resolve(true);
       };
 

--- a/test/locky.js
+++ b/test/locky.js
@@ -223,13 +223,13 @@ describe('Locky', () => {
   describe('#close', () => {
     beforeEach(() => {
       locky = createLocky();
-      sinon.spy(locky.redis, 'quit');
+      sinon.spy(locky.redis, 'end');
     });
 
     it('should close the redis connection', () => {
       return locky.close()
       .then(() => {
-        expect(locky.redis.quit).to.be.called;
+        expect(locky.redis.end).to.be.called;
         locky = null;
         return true;
       });


### PR DESCRIPTION
Corrige les erreurs liées à des commandes redis jouées après avoir quitter le service redis.