### PR TITLE
fix(expirate worker): infinite loop

### DIFF
--- a/lib/locky.js
+++ b/lib/locky.js
@@ -12,6 +12,7 @@ const resourceKey = require("./resource-key");
  * @property {ReturnType<import('util').promisify<RedisClient["pexpire"]>>} pexpire
  * @property {ReturnType<import('util').promisify<RedisClient["quit"]>>} quit
  * @property {ReturnType<import('util').promisify<RedisClient["smembers"]>>} smembers
+ * @property {ReturnType<import('util').promisify<RedisClient["ttl"]>>} ttl
  * @property {ReturnType<import('util').promisify<RedisClient["del"]>>} del
  * @property {ReturnType<import('util').promisify<RedisClient["watch"]>>} watch
  */
@@ -29,6 +30,7 @@ const promisifyRedisClient = (client) => {
     smembers: promisify(client.smembers.bind(client)),
     del: promisify(client.del.bind(client)),
     watch: promisify(client.watch.bind(client)),
+    ttl: promisify(client.pttl.bind(client)),
   };
 
   /** @type {AsyncRedisClient} */ (client).promises = promises;
@@ -319,8 +321,12 @@ class Locky extends EventEmitter {
         await this.runOperation(async () => {
           const trx = this.expirationWorker.redis.multi();
           const key = `${this.prefix}expirate:worker`;
+          const ttlWorker = await this.redis.promises.ttl(key);
+
           trx.setnx(key, "OK");
-          trx.pexpire(key, /** @type {number} */ (this.ttl));
+          if (ttlWorker === -2) { //the key does not exist, avoid override (eq. NX)
+            trx.pexpire(key, /** @type {number} */ (this.ttl));
+          }
           const [locked] = await promisify(trx.exec.bind(trx))();
 
           if (locked) {


### PR DESCRIPTION
1. il a pas réussi a faire le `del` (panne)
2. il est donc `locked`
3. mais toute les `ttl/10`  on remette le `ttl` de base
4. du coup il passe jamais dans le expire worker

(command `NX` pas disponible sur notre version de redis)