### PR TITLE
chore: bump redis to 5.10.0

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - name: Check out repository code

--- a/__tests__/locky.js
+++ b/__tests__/locky.js
@@ -37,7 +37,7 @@ describe("Locky", () => {
     if (locky) {
       await locky.close();
     }
-    await testRedis.quit();
+    await testRedis.close();
   });
 
   describe("#lock", () => {

--- a/lib/locky.js
+++ b/lib/locky.js
@@ -10,6 +10,7 @@ const resourceKey = require("./resource-key");
  * @typedef RedisPromises
  * @property {ReturnType<import('util').promisify<RedisClient["get"]>>} get
  * @property {ReturnType<import('util').promisify<RedisClient["set"]>>} set
+ * @property {ReturnType<import('util').promisify<RedisClient["sAdd"]>>} sAdd
  * @property {ReturnType<import('util').promisify<RedisClient["pexpire"]>>} pexpire
  * @property {ReturnType<import('util').promisify<RedisClient["quit"]>>} quit
  * @property {ReturnType<import('util').promisify<RedisClient["smembers"]>>} smembers
@@ -159,7 +160,7 @@ class Locky extends EventEmitter {
 
       const [, setResult] = await trx.exec();
 
-      const success = setResult !== null && setResult !== 0;
+      const success = setResult !== null;
 
       if (success) {
         await this.asyncEmit("lock", resource, locker);
@@ -199,7 +200,9 @@ class Locky extends EventEmitter {
       const key = resourceKey.format(this.prefix, resource);
 
       // Set the TTL of the key.
-      return this.redis.pExpire(key, this.ttl);
+      const expire = await this.redis.pExpire(key, this.ttl);
+
+      return expire === 1;
     });
   }
 
@@ -234,7 +237,7 @@ class Locky extends EventEmitter {
       trx.del(key);
       const [, res] = await trx.exec();
 
-      const success = res !== 0;
+      const success = /** @type {number} */ (/** @type {any} */ (res)) !== 0;
 
       if (success) {
         await this.asyncEmit("unlock", resource);
@@ -302,7 +305,10 @@ class Locky extends EventEmitter {
     if (this.expirationWorker?.timeout) {
       clearTimeout(this.expirationWorker.timeout);
     }
-    await Promise.all([this.redis.quit(), this.expirationWorker?.redis.quit()]);
+    await Promise.all([
+      this.redis.close(),
+      this.expirationWorker?.redis.close(),
+    ]);
   }
 
   /**
@@ -340,9 +346,12 @@ class Locky extends EventEmitter {
         this.asyncEmit("error", error);
       }
 
-      this.expirationWorker.timeout = setTimeout(() => {
-        run();
-      }, /** @type {number} */ (this.ttl) / 10);
+      this.expirationWorker.timeout = setTimeout(
+        () => {
+          run();
+        },
+        /** @type {number} */ (this.ttl) / 10,
+      );
     };
 
     run();
@@ -362,7 +371,9 @@ class Locky extends EventEmitter {
 
     const ttlBatch = redisClient.multi();
     keys.forEach((key) => ttlBatch.pTTL(key));
-    const ttls = await ttlBatch.exec();
+    const ttls = /** @type {number[]} */ (
+      /** @type {any[]} */ (await ttlBatch.exec())
+    );
 
     const keysToExpire = keys.filter((_, index) => ttls[index] === -2);
 
@@ -380,8 +391,8 @@ class Locky extends EventEmitter {
 
     await Promise.all(
       keysToExpire.map((key) =>
-        this.asyncEmit("expire", resourceKey.parse(this.prefix, key))
-      )
+        this.asyncEmit("expire", resourceKey.parse(this.prefix, key)),
+      ),
     );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
-        "redis": "^4.7.0"
+        "redis": "^5.10.0"
       },
       "devDependencies": {
         "conventional-github-releaser": "^3.1.5",
@@ -999,62 +999,63 @@
       }
     },
     "node_modules/@redis/bloom": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
-      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz",
+      "integrity": "sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.10.0"
       }
     },
     "node_modules/@redis/client": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
-      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
+      "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
       "license": "MIT",
       "dependencies": {
-        "cluster-key-slot": "1.1.2",
-        "generic-pool": "3.9.0",
-        "yallist": "4.0.0"
+        "cluster-key-slot": "1.1.2"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@redis/graph": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
-      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "node": ">= 18"
       }
     },
     "node_modules/@redis/json": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
-      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.10.0.tgz",
+      "integrity": "sha512-B2G8XlOmTPUuZtD44EMGbtoepQG34RCDXLZbjrtON1Djet0t5Ri7/YPXvL9aomXqP8lLTreaprtyLKF4tmXEEA==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.10.0"
       }
     },
     "node_modules/@redis/search": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
-      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.10.0.tgz",
+      "integrity": "sha512-3SVcPswoSfp2HnmWbAGUzlbUPn7fOohVu2weUQ0S+EMiQi8jwjL+aN2p6V3TI65eNfVsJ8vyPvqWklm6H6esmg==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.10.0"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
-      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz",
+      "integrity": "sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.10.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -3178,15 +3179,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "node_modules/generic-pool": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
-      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -5898,20 +5890,19 @@
       }
     },
     "node_modules/redis": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
-      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
+      "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
       "license": "MIT",
-      "workspaces": [
-        "./packages/*"
-      ],
       "dependencies": {
-        "@redis/bloom": "1.2.0",
-        "@redis/client": "1.6.0",
-        "@redis/graph": "1.1.1",
-        "@redis/json": "1.0.7",
-        "@redis/search": "1.2.0",
-        "@redis/time-series": "1.1.0"
+        "@redis/bloom": "5.10.0",
+        "@redis/client": "5.10.0",
+        "@redis/json": "5.10.0",
+        "@redis/search": "5.10.0",
+        "@redis/time-series": "5.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/repeating": {
@@ -7294,7 +7285,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "17.5.1",
@@ -8101,43 +8093,35 @@
       }
     },
     "@redis/bloom": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
-      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz",
+      "integrity": "sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==",
       "requires": {}
     },
     "@redis/client": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
-      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
+      "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
       "requires": {
-        "cluster-key-slot": "1.1.2",
-        "generic-pool": "3.9.0",
-        "yallist": "4.0.0"
+        "cluster-key-slot": "1.1.2"
       }
     },
-    "@redis/graph": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
-      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
-      "requires": {}
-    },
     "@redis/json": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
-      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.10.0.tgz",
+      "integrity": "sha512-B2G8XlOmTPUuZtD44EMGbtoepQG34RCDXLZbjrtON1Djet0t5Ri7/YPXvL9aomXqP8lLTreaprtyLKF4tmXEEA==",
       "requires": {}
     },
     "@redis/search": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
-      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.10.0.tgz",
+      "integrity": "sha512-3SVcPswoSfp2HnmWbAGUzlbUPn7fOohVu2weUQ0S+EMiQi8jwjL+aN2p6V3TI65eNfVsJ8vyPvqWklm6H6esmg==",
       "requires": {}
     },
     "@redis/time-series": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
-      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz",
+      "integrity": "sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==",
       "requires": {}
     },
     "@sinclair/typebox": {
@@ -9823,11 +9807,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "generic-pool": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
-      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -11896,16 +11875,15 @@
       }
     },
     "redis": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
-      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
+      "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
       "requires": {
-        "@redis/bloom": "1.2.0",
-        "@redis/client": "1.6.0",
-        "@redis/graph": "1.1.1",
-        "@redis/json": "1.0.7",
-        "@redis/search": "1.2.0",
-        "@redis/time-series": "1.1.0"
+        "@redis/bloom": "5.10.0",
+        "@redis/client": "5.10.0",
+        "@redis/json": "5.10.0",
+        "@redis/search": "5.10.0",
+        "@redis/time-series": "5.10.0"
       }
     },
     "repeating": {
@@ -12950,7 +12928,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "17.5.1",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "standard-version": "^9.5.0",
     "typescript": "^4.7.4"
   },
-  "dependencies": {
-    "redis": "^4.7.0"
-  },
   "engines": {
     "node": ">= 12.9.0"
+  },
+  "dependencies": {
+    "redis": "^5.10.0"
   }
 }


### PR DESCRIPTION
Bump redis to [5.10.0](https://github.com/redis/node-redis/releases/tag/redis%405.10.0)